### PR TITLE
Fixed OMetaMacroTest

### DIFF
--- a/src/Boo.OMeta.Tests/OMetaMacroTest.boo
+++ b/src/Boo.OMeta.Tests/OMetaMacroTest.boo
@@ -267,4 +267,4 @@ class OMetaMacroTest:
 		match m:
 			case SuccessfulMatch(Value, Input):
 				assert Input.IsEmpty, "Unexpected ${Input.Head}"
-				Assert.AreEqual(expected, Value)
+				Assert.IsTrue(expected.Equals(Value))

--- a/src/Boo.OMeta.Tests/OMetaMacroTest.boo
+++ b/src/Boo.OMeta.Tests/OMetaMacroTest.boo
@@ -255,7 +255,25 @@ class OMetaMacroTest:
 		match HexParser().parse("0xff"):
 			case SuccessfulMatch(Value: "ff"):
 				pass
+	
+	[Test]
+	def TestExplodeInput():
 		
+		ometa ExplodeInput:
+			match = *john_or_paul
+			john = "John "
+			paul = "Paul "
+			john_or_paul = john | paul
+			
+		def john_or_paul(person): 
+			return ExplodeInput().match(OMetaInput.Singleton(person))
+		
+		o = john_or_paul("John Stewart")
+		
+		match o:
+			case SuccessfulMatch(Input):
+				assert Input.IsEmpty
+	
 	def assertE(grammar as OMetaGrammar):
 		assertRule grammar, 'exp', "11+31", [['1', '1'], '+', ['3', '1']]
 		assertRule grammar, 'exp', "1+2*3", [['1'], '+', [['2'], '*', ['3']]]

--- a/src/Boo.OMeta/OMetaMacroRuleProcessor.boo
+++ b/src/Boo.OMeta/OMetaMacroRuleProcessor.boo
@@ -245,6 +245,29 @@ class OMetaMacroRuleProcessor:
 				
 			case [| ~$rule |]:
 				expandNegation block, rule, input, lastMatch
+
+			case [| *$rule |]:
+				temp = uniqueName()
+				inputCode = [|
+					$temp = $input
+					if $temp.Head isa System.Collections.IEnumerable:
+						$input = OMetaInput.For($temp.Head)
+				|]
+				block.Add(inputCode)
+				expand block, rule, input, lastMatch
+				
+				code = [|
+					block:
+						smatch = $lastMatch as SuccessfulMatch
+						if $temp.Head isa System.Collections.IEnumerable: //If input was exploded
+							if smatch is not null:
+								$lastMatch = SuccessfulMatch($temp.Tail, smatch.Value)  //Move input to the next position if success
+							else:
+								$lastMatch = FailedMatch($temp, ($lastMatch as FailedMatch).Failure) //Restore input if rule failed
+				|].Body
+				
+				block.Add(code)
+				
 				
 			case MemberReferenceExpression(Target: t, Name: n):
 				block.Add([| $lastMatch = $t.$n($input) |])


### PR DESCRIPTION
Assert.AreEqual changed to Assert.IsTrue because per official NUnit documentation Assert.AreEqual doesn't support multidimensional array. (http://www.nunit.org/index.php?p=comparisonAsserts&r=2.2)
